### PR TITLE
Adapt the development server to accept multiple server configurations

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -71,7 +71,7 @@ reload the web application on demand.
 ```ts
 import { Server } from '@pixelart/packmule';
 import configuration from './webpack.config.ts';
-import * as options from './.browsersyncrc.json';
+import options from './.browsersyncrc.json';
 
 const server = new Server(configuration({
     development: true,
@@ -80,3 +80,6 @@ const server = new Server(configuration({
 
 server.launch();
 ```
+
+`options` can be a `browser-sync` configuration object or an
+array of configuration objects, to launch multiple servers.

--- a/src/Utility/Server.ts
+++ b/src/Utility/Server.ts
@@ -15,7 +15,7 @@ export default class Server {
         this.browsersyncOptions = Array.isArray(browsersyncOptions) ? browsersyncOptions : [browsersyncOptions];
     }
 
-    public launch(name?: string): browsersync.BrowserSyncInstance | browsersync.BrowserSyncInstance[] {
+    public launch(): browsersync.BrowserSyncInstance | browsersync.BrowserSyncInstance[] {
         const instances: browsersync.BrowserSyncInstance[]  = [];
         const compiler = webpack(this.webpackConfiguration);
 
@@ -32,7 +32,7 @@ export default class Server {
         });
 
         this.browsersyncOptions.forEach((options) => {
-            const server = browsersync.create(name).init({...options, ...{
+            const server = browsersync.create().init({...options, ...{
                 middleware: [
                     dev,
                     hmr,

--- a/src/Utility/Server.ts
+++ b/src/Utility/Server.ts
@@ -5,18 +5,18 @@ import webpackHotMiddleware from 'webpack-hot-middleware';
 
 export default class Server {
     private readonly webpackConfiguration: webpack.Configuration;
-    private readonly browsersyncOptions: browsersync.Options;
+    private readonly browsersyncOptions: browsersync.Options[];
 
     public constructor(
         webpackConfiguration: webpack.Configuration,
-        browsersyncOptions: browsersync.Options = {},
+        browsersyncOptions: browsersync.Options | browsersync.Options[] = {},
     ) {
         this.webpackConfiguration = webpackConfiguration;
-        this.browsersyncOptions = browsersyncOptions;
+        this.browsersyncOptions = Array.isArray(browsersyncOptions) ? browsersyncOptions : [browsersyncOptions];
     }
 
-    public launch(): browsersync.BrowserSyncInstance {
-        const server = browsersync.create();
+    public launch(name?: string): browsersync.BrowserSyncInstance | browsersync.BrowserSyncInstance[] {
+        const instances: browsersync.BrowserSyncInstance[]  = [];
         const compiler = webpack(this.webpackConfiguration);
 
         const dev = webpackDevMiddleware(compiler, {
@@ -31,11 +31,17 @@ export default class Server {
             log: false,
         });
 
-        return server.init({...this.browsersyncOptions, ...{
-            middleware: [
-                dev,
-                hmr,
-            ],
-        }});
+        this.browsersyncOptions.forEach((options) => {
+            const server = browsersync.create(name).init({...options, ...{
+                middleware: [
+                    dev,
+                    hmr,
+                ],
+            }});
+
+            instances.push(server);
+        });
+
+        return instances.length === 1 ? instances[0] : instances;
     }
 }


### PR DESCRIPTION
This allows to configure/run multiple `browser-sync` servers in parallel while sharing the same webpack compiler instance.

This shouldn't break backwards-compatibility as the class still handles a single server.

**Single Server**
```ts
const server = new Server(webpackConfig, {...options});
server.launch();
```

**Multiple Servers**
```ts
const server = new Server(webpackConfig, [
  {...options1},
  {...options2}
]);
server.launch();
```

Closes #3.