### PR TITLE
Add API method to the service worker pack to configure runtime caching

### DIFF
--- a/src/Packs/ServiceWorkerPack.ts
+++ b/src/Packs/ServiceWorkerPack.ts
@@ -9,6 +9,7 @@ interface ServiceWorkerPackOptions {
 }
 
 export default class ServiceWorkerPack implements Pack {
+    private caches: any[] = [];
     private options: ServiceWorkerPackOptions;
     private defaults: ServiceWorkerPackOptions = {
         include: () => true,
@@ -35,12 +36,21 @@ export default class ServiceWorkerPack implements Pack {
         return this;
     }
 
+    public cache(urlPattern: RegExp, handler: string, options?: any): void {
+        this.caches.push({
+            urlPattern,
+            handler,
+            options,
+        });
+    }
+
     public generate(): webpack.Configuration {
         const configuration: any = {
             clientsClaim: true,
             skipWaiting: true,
             importWorkboxFrom: 'local',
             include: this.options.include,
+            runtimeCaching: this.caches,
         };
 
         if (this.options.path) {

--- a/src/Packs/ServiceWorkerPack.ts
+++ b/src/Packs/ServiceWorkerPack.ts
@@ -36,12 +36,14 @@ export default class ServiceWorkerPack implements Pack {
         return this;
     }
 
-    public cache(urlPattern: RegExp, handler: string, options?: any): void {
+    public cache(urlPattern: RegExp, handler: string, options?: any): this {
         this.caches.push({
             urlPattern,
             handler,
             options,
         });
+
+        return this;
     }
 
     public generate(): webpack.Configuration {


### PR DESCRIPTION
Enables configuration of [runtime caching](https://developers.google.com/web/tools/workbox/modules/workbox-webpack-plugin#generateSW-runtimeCaching) for the service worker pack.