### PR TITLE
Use esbuild for script optimization

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,12 +27,11 @@
     "access": "public"
   },
   "dependencies": {
+    "esbuild-webpack-plugin": "^1.0.3",
     "pkg-dir": "^4.2.0",
-    "terser-webpack-plugin": "^3.0.0",
     "webpack-merge": "^5.0.7"
   },
   "devDependencies": {
-    "@types/terser-webpack-plugin": "^3.0.0",
     "@types/webpack-merge": "^4.1.5"
   },
   "peerDependencies": {

--- a/packages/core/src/packs/minification.ts
+++ b/packages/core/src/packs/minification.ts
@@ -1,5 +1,5 @@
 import webpack from 'webpack';
-import TerserPlugin from 'terser-webpack-plugin';
+import OptimizationPlugin from 'esbuild-webpack-plugin';
 import Pack from '../common/pack';
 import Hints from '../common/hints';
 import Options from '../common/options';
@@ -13,12 +13,11 @@ export default class MinificationPack implements Pack {
 
     public generate(options: Options, hints: Hints): webpack.Configuration {
         if (hints.optimize) {
-            const terser = new TerserPlugin({
-                cache: hints.cache,
-                sourceMap: hints.map,
+            const optimization = new OptimizationPlugin({
+                minify: true,
             });
 
-            this.configuration.optimization!.minimizer!.push(terser);
+            this.configuration.optimization!.minimizer!.push(optimization);
         }
 
         return this.configuration;

--- a/packages/core/test/packs/minification.ts
+++ b/packages/core/test/packs/minification.ts
@@ -1,5 +1,5 @@
 import test from 'ava';
-import TerserPlugin from 'terser-webpack-plugin';
+import OptimizationPlugin from 'esbuild-webpack-plugin';
 import Pack from '../../src/packs/minification';
 
 test('pack instantiation', (t) => {
@@ -24,7 +24,7 @@ test('minification is enabled for the optimize option', (t) => {
         },
     );
 
-    const result = configuration.optimization!.minimizer!.some((minimizer) => minimizer instanceof TerserPlugin);
+    const result = configuration.optimization!.minimizer!.some((minimizer) => minimizer instanceof OptimizationPlugin);
 
     t.true(result);
 });


### PR DESCRIPTION
By using esbuild instead of terser for script optimization, build times should be a lot shorter.